### PR TITLE
feature: LoginUser와 RedisHashLoginUser를 모두 사용할 수 있도록 구현.

### DIFF
--- a/src/main/java/com/example/freshcart/global/infra/InMemorySessionManager.java
+++ b/src/main/java/com/example/freshcart/global/infra/InMemorySessionManager.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 HttpSession 객체를 직접 구현
 HashMap - 세션 저장소
  */
-@Component
 @Slf4j
 public class InMemorySessionManager implements SessionManager {
 

--- a/src/main/java/com/example/freshcart/global/infra/SessionRedisRepository.java
+++ b/src/main/java/com/example/freshcart/global/infra/SessionRedisRepository.java
@@ -1,17 +1,17 @@
 package com.example.freshcart.global.infra;
 
-import com.example.freshcart.user.application.LoginUser;
+import com.example.freshcart.user.application.RedisHashLoginUser;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
-public interface SessionRedisRepository extends CrudRepository<LoginUser, String> {
+public interface SessionRedisRepository extends CrudRepository<RedisHashLoginUser, String> {
 
   @Override
-  LoginUser save(LoginUser user);
+  RedisHashLoginUser save(RedisHashLoginUser user);
 
   @Override
-  List<LoginUser> findAll();
+  List<RedisHashLoginUser> findAll();
 
-  Optional<LoginUser> findBySessionId(String value);
+  Optional<RedisHashLoginUser> findBySessionId(String value);
 }

--- a/src/main/java/com/example/freshcart/global/infra/SessionRedisRepository.java
+++ b/src/main/java/com/example/freshcart/global/infra/SessionRedisRepository.java
@@ -13,5 +13,5 @@ public interface SessionRedisRepository extends CrudRepository<RedisHashLoginUse
   @Override
   List<RedisHashLoginUser> findAll();
 
-  Optional<RedisHashLoginUser> findBySessionId(String value);
+  RedisHashLoginUser findBySessionId(String value);
 }

--- a/src/main/java/com/example/freshcart/user/application/RedisHashLoginUser.java
+++ b/src/main/java/com/example/freshcart/user/application/RedisHashLoginUser.java
@@ -14,10 +14,12 @@ import org.springframework.data.redis.core.index.Indexed;
  * 트랜잭션을 지원하지 않기 때문에 만약 트랜잭션을 적용하고 싶다면 RedisTemplate 을 사용해야 합니다.
  */
 
-public class LoginUser {
+@RedisHash(value = "LoginUser", timeToLive = 120)
+public class RedisHashLoginUser {
 
   @Id
   private String id;
+  @Indexed
   private String sessionId;
   private Long userId;
   private String email;
@@ -25,7 +27,7 @@ public class LoginUser {
   private LocalDateTime createdAt;
 
 
-  public LoginUser(String sessionId, Long userId, String email,
+  public RedisHashLoginUser(String sessionId, Long userId, String email,
       Role role, LocalDateTime createdAt) {
     this.sessionId = sessionId;
     this.userId = userId;
@@ -34,10 +36,9 @@ public class LoginUser {
     this.createdAt = createdAt;
   }
 
-
-  public static LoginUser of(String sessionId, Long userId, String email, Role role,
+  public static RedisHashLoginUser of(String sessionId, Long userId, String email, Role role,
       LocalDateTime createdAt) {
-    return new LoginUser(sessionId, userId, email, role, createdAt);
+    return new RedisHashLoginUser(sessionId, userId, email, role, createdAt);
   }
 
 
@@ -47,6 +48,10 @@ public class LoginUser {
 
   public String getSessionId() {
     return sessionId;
+  }
+
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
   }
 
   public String getEmail() {
@@ -64,8 +69,5 @@ public class LoginUser {
   public String getId() {
     return id;
   }
-
-  public void setSessionId(String sessionId) {
-    this.sessionId = sessionId;
-  }
 }
+


### PR DESCRIPTION
[개요]
Redis를 쓰거나, Redis 를 쓰지 않을 때도 코드의 변경이 적도록 리팩토링. 
RedisSessionManager에서 조회 후 객체의 타입을 변환해줌으로써 Controller이후의 코드에 영향을 미치지 않음. 

[테스트 내역]
-레디스를 사용하지 않은 InMemory, Redis 활용 기능 모두 로그인 잘 됨 
-로그인 어노테이션으로 제품 등록도 잘 됨. 