### PR TITLE
주문에 따른 재고 차감 기능

### DIFF
--- a/src/main/java/com/example/freshcart/optionstock/application/OptionStockService.java
+++ b/src/main/java/com/example/freshcart/optionstock/application/OptionStockService.java
@@ -6,10 +6,8 @@ import com.example.freshcart.optionstock.application.command.OptionStockAddComma
 import com.example.freshcart.optionstock.application.command.OptionStockUpdateCommand;
 import com.example.freshcart.optionstock.domain.OptionStock;
 import com.example.freshcart.optionstock.domain.OptionStockRepository;
-import com.example.freshcart.order.domain.OrderItem;
 import com.example.freshcart.product.application.ProductService;
 import com.example.freshcart.product.domain.Option;
-import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -39,9 +37,4 @@ public class OptionStockService {
     optionStockRepository.save(optionStock);
   }
 
-  //주문으로 Stock이 줄어듦.
-  public void reduceStock(List<OrderItem> orderItemList){
-    //재고가 없다면, 재고 없다 exception
-    //Order orderItem의 Id 확인
-  }
 }

--- a/src/main/java/com/example/freshcart/optionstock/domain/OptionStock.java
+++ b/src/main/java/com/example/freshcart/optionstock/domain/OptionStock.java
@@ -8,10 +8,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "option_inventory")
 @Getter
+@NoArgsConstructor
 public class OptionStock extends Timestamped {
 
   @Id
@@ -34,11 +36,12 @@ public class OptionStock extends Timestamped {
     this.stock = stock;
   }
 
-  public OptionStock() {
 
+  public void changeStock(int stock) {
+    this.stock = stock;
   }
 
-  public void changeStock(int stock){
-    this.stock = stock;
+  public void reduceStock(int stock) {
+    this.stock -= stock;
   }
 }

--- a/src/main/java/com/example/freshcart/optionstock/domain/exception/OptionStockNotAvailableException.java
+++ b/src/main/java/com/example/freshcart/optionstock/domain/exception/OptionStockNotAvailableException.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public class OptionStockNotAvailableException extends BaseException {
 
   // static 변수 할당으로 인스턴스를 생성하지 않고도 사용 가능하게 함. 변수가 super() 생성자에서도 참조되기 위함.
-  private static final String message = "존재하지 않는 재고 입니다";
+  private static final String message = "제품의 재고가 부족합니다.";
 
   public OptionStockNotAvailableException() {
     super(HttpStatus.NOT_FOUND, message);

--- a/src/main/java/com/example/freshcart/order/application/CartToOrderMapper.java
+++ b/src/main/java/com/example/freshcart/order/application/CartToOrderMapper.java
@@ -23,7 +23,7 @@ public class CartToOrderMapper {
         cart.getReceiverPhone(),
         cart.getReceiverAddress(),
         OrderStatus.ORDER_CREATED,
-        cart.getCartItemCommands().stream().map(this::toOrderItem)
+        cart.getCartItems().stream().map(this::toOrderItem)
             .collect(toList()));
 
   }

--- a/src/main/java/com/example/freshcart/order/application/OrderRegisterProcessor.java
+++ b/src/main/java/com/example/freshcart/order/application/OrderRegisterProcessor.java
@@ -1,50 +1,98 @@
 package com.example.freshcart.order.application;
 
 import com.example.freshcart.authentication.application.LoginUser;
+import com.example.freshcart.optionstock.application.OptionStockService;
+import com.example.freshcart.optionstock.domain.OptionStockRepository;
+import com.example.freshcart.optionstock.domain.exception.OptionStockNotAvailableException;
 import com.example.freshcart.order.application.command.CartCommand;
 import com.example.freshcart.order.domain.Order;
+import com.example.freshcart.order.domain.OrderItem;
+import com.example.freshcart.order.domain.OrderItemOption;
+import com.example.freshcart.order.domain.OrderItemOptionGroup;
 import com.example.freshcart.order.domain.OrderRepository;
+import java.util.List;
 
 
 /**
- * 역할: 주문을 등록
- * 협력
- * (1) CartToOrderMapper: 주문 요청 객체인 Cart를 Order로 변환.
- * (2) orderValidator: 카트에 담은 이후 제품 정보 등이 바뀌었을 경우를 대비하여, 옵션과 일치하는지 체크
- * (3) OrderRepository: 저장소와 data operation 작업 위임
- * OrderRepository와 OrderItemRegisterV1은 다른 구현체로 바뀔 가능성이 있다.
+ * 역할: 주문을 등록 협력 (1) CartToOrderMapper: 주문 요청 객체인 Cart를 Order로 변환. (2) orderValidator: 카트에 담은 이후 제품
+ * 정보 등이 바뀌었을 경우를 대비하여, 옵션과 일치하는지 체크 (3) OrderRepository: 저장소와 data operation 작업 위임 OrderRepository와
+ * OrderItemRegisterV1은 다른 구현체로 바뀔 가능성이 있다.
+ *
+ * 우선 3중 for 문으로라도 inventory check 되게 만들기.
  */
 
 public class OrderRegisterProcessor {
 
   private final CartToOrderMapper cartToOrderMapper;
   private final OrderValidator orderValidator;
+  private final OptionStockService optionStockService;
   private final OrderRepository orderRepository;
+  private final OptionStockRepository optionStockRepository;
 
   public OrderRegisterProcessor(
       CartToOrderMapper cartToOrderMapper,
       OrderValidator orderValidator,
-      OrderRepository orderRepository) {
+      OptionStockService optionStockService,
+      OrderRepository orderRepository,
+      OptionStockRepository optionStockRepository) {
     this.cartToOrderMapper = cartToOrderMapper;
     this.orderValidator = orderValidator;
+    this.optionStockService = optionStockService;
     this.orderRepository = orderRepository;
+    this.optionStockRepository = optionStockRepository;
   }
+
 
   public void place(LoginUser user, CartCommand cart) {
     Order order = cartToOrderMapper.mapFrom(user, cart);
     orderValidator.validate(order);
-    checkInventory(); // Inventory 별도 필요
+    convertToOptionList(order.getOrderItemList()); // Inventory 별도 필요
     save(user, order);
   }
 
-  public void checkInventory(){
+  //주문서에 재고가 없는 제품이 있을 경우, Exception
 
+//  public List<OrderItemOption> mapToOptionList(List<OrderItem> orderItemList){
+//    orderItemList.stream().map(orderItem -> OrderItem.getOrderItemOptionGroups()).collect(toList());
+//    return new
+//  }
+
+
+  public void convertToOptionList(List<OrderItem> orderItemList) {
+    for(OrderItem x: orderItemList){
+      int count = x.getCount();
+      List<OrderItemOptionGroup> orderItemOptionGroups = x.getOrderItemOptionGroups();
+      for(OrderItemOptionGroup y: orderItemOptionGroups){
+        List<OrderItemOption> orderItemOptionList = y.getOrderItemOptions();
+        for(OrderItemOption z: orderItemOptionList){
+          checkInventory(z, count);
+        }
+      }
+    }
+
+    //orderItemList의 orderItem을 하나씩 꺼내서, OrderItem의 getOptionGroup을 가져오고, OrderItemOptionGroup에서 OrderItemOption을 꺼낸다.
+    //OrderItemOption의 productOptionId를 찾는다.
+    //Inventory로 조회해보면서, 재고가 있는지 확인한다.
+
+//    orderItemList.getOrderItem().getOrderItemOptionGroups().get
+//
+//    orderItemList.forEach(orderItem -> {
+//      if () {
+//        throw new OptionStockNotAvailableException();
+//      }
+//    });
   }
+
+  public void checkInventory(OrderItemOption option, int count){
+    if (optionStockRepository.findById(option.getProductOptionId()).getStock()<count) {
+      throw new OptionStockNotAvailableException();
+    }
+  }
+
   public Order save(LoginUser user, Order order) {
     orderRepository.save(user, order);
     return order;
   }
-
 
 
 }

--- a/src/main/java/com/example/freshcart/order/application/OrderRegisterProcessor.java
+++ b/src/main/java/com/example/freshcart/order/application/OrderRegisterProcessor.java
@@ -2,8 +2,10 @@ package com.example.freshcart.order.application;
 
 import com.example.freshcart.authentication.application.LoginUser;
 import com.example.freshcart.optionstock.application.OptionStockService;
+import com.example.freshcart.optionstock.domain.OptionStock;
 import com.example.freshcart.optionstock.domain.OptionStockRepository;
 import com.example.freshcart.optionstock.domain.exception.OptionStockNotAvailableException;
+import com.example.freshcart.optionstock.domain.exception.OptionStockNotFoundException;
 import com.example.freshcart.order.application.command.CartCommand;
 import com.example.freshcart.order.domain.Order;
 import com.example.freshcart.order.domain.OrderItem;
@@ -11,14 +13,13 @@ import com.example.freshcart.order.domain.OrderItemOption;
 import com.example.freshcart.order.domain.OrderItemOptionGroup;
 import com.example.freshcart.order.domain.OrderRepository;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 
 /**
  * 역할: 주문을 등록 협력 (1) CartToOrderMapper: 주문 요청 객체인 Cart를 Order로 변환. (2) orderValidator: 카트에 담은 이후 제품
  * 정보 등이 바뀌었을 경우를 대비하여, 옵션과 일치하는지 체크 (3) OrderRepository: 저장소와 data operation 작업 위임 OrderRepository와
  * OrderItemRegisterV1은 다른 구현체로 바뀔 가능성이 있다.
- *
- * 우선 3중 for 문으로라도 inventory check 되게 만들기.
  */
 
 public class OrderRegisterProcessor {
@@ -43,6 +44,7 @@ public class OrderRegisterProcessor {
   }
 
 
+  @Transactional
   public void place(LoginUser user, CartCommand cart) {
     Order order = cartToOrderMapper.mapFrom(user, cart);
     orderValidator.validate(order);
@@ -50,42 +52,28 @@ public class OrderRegisterProcessor {
     save(user, order);
   }
 
-  //주문서에 재고가 없는 제품이 있을 경우, Exception
-
-//  public List<OrderItemOption> mapToOptionList(List<OrderItem> orderItemList){
-//    orderItemList.stream().map(orderItem -> OrderItem.getOrderItemOptionGroups()).collect(toList());
-//    return new
-//  }
-
-
   public void convertToOptionList(List<OrderItem> orderItemList) {
-    for(OrderItem x: orderItemList){
+    for (OrderItem x : orderItemList) {
       int count = x.getCount();
       List<OrderItemOptionGroup> orderItemOptionGroups = x.getOrderItemOptionGroups();
-      for(OrderItemOptionGroup y: orderItemOptionGroups){
+      for (OrderItemOptionGroup y : orderItemOptionGroups) {
         List<OrderItemOption> orderItemOptionList = y.getOrderItemOptions();
-        for(OrderItemOption z: orderItemOptionList){
+        for (OrderItemOption z : orderItemOptionList) {
           checkInventory(z, count);
         }
       }
     }
-
-    //orderItemList의 orderItem을 하나씩 꺼내서, OrderItem의 getOptionGroup을 가져오고, OrderItemOptionGroup에서 OrderItemOption을 꺼낸다.
-    //OrderItemOption의 productOptionId를 찾는다.
-    //Inventory로 조회해보면서, 재고가 있는지 확인한다.
-
-//    orderItemList.getOrderItem().getOrderItemOptionGroups().get
-//
-//    orderItemList.forEach(orderItem -> {
-//      if () {
-//        throw new OptionStockNotAvailableException();
-//      }
-//    });
   }
 
-  public void checkInventory(OrderItemOption option, int count){
-    if (optionStockRepository.findById(option.getProductOptionId()).getStock()<count) {
+  public void checkInventory(OrderItemOption option, int count) {
+    OptionStock optionStock = optionStockRepository.findById(option.getProductOptionId());
+    if (optionStock == null) {
+      throw new OptionStockNotFoundException();
+    }
+    if (optionStock.getStock() < count) {
       throw new OptionStockNotAvailableException();
+    } else {
+      optionStock.reduceStock(count);
     }
   }
 

--- a/src/main/java/com/example/freshcart/order/application/OrderValidator.java
+++ b/src/main/java/com/example/freshcart/order/application/OrderValidator.java
@@ -13,7 +13,8 @@ import com.example.freshcart.product.domain.ProductRepository;
 
 
 /**
- * OrderValidator 역할: 제품의 이름, 옵션 그룹 등과 일치하는 이름으로 주문서를 작성했는지 등 확인 (중간에 제품이 수정되어 잘못된 데이터로 주문하는 것을 방지하기
+ * OrderValidator
+ * 역할: 제품의 이름, 옵션 그룹 등과 일치하는 이름으로 주문서를 작성했는지 등 확인 (중간에 제품이 수정되어 잘못된 데이터로 주문하는 것을 방지하기
  * 위해서)
  */
 

--- a/src/main/java/com/example/freshcart/order/application/command/CartCommand.java
+++ b/src/main/java/com/example/freshcart/order/application/command/CartCommand.java
@@ -1,10 +1,13 @@
 package com.example.freshcart.order.application.command;
 
 import java.util.List;
+import lombok.Getter;
 
 /**
  * presentation 계층의 Cart를 바로 쓰지 않고, application 층 내에서 Command 로 변환해서 사용
  */
+
+@Getter
 public class CartCommand {
 
   private String receiverName;
@@ -23,23 +26,6 @@ public class CartCommand {
     this.receiverAddress = receiverAddress;
     this.cartItems = cartItems;
   }
-
-  public String getReceiverName() {
-    return receiverName;
-  }
-
-  public String getReceiverPhone() {
-    return receiverPhone;
-  }
-
-  public String getReceiverAddress() {
-    return receiverAddress;
-  }
-
-  public List<CartItemCommand> getCartItemCommands() {
-    return cartItems;
-  }
-
 
   /**
    * CartItem은 Product, OrderLineItem과 매칭

--- a/src/main/java/com/example/freshcart/order/domain/Order.java
+++ b/src/main/java/com/example/freshcart/order/domain/Order.java
@@ -2,7 +2,9 @@ package com.example.freshcart.order.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class Order {
 
   private Long id;
@@ -36,42 +38,6 @@ public class Order {
     this.receiverAddress = receiverAddress;
     this.orderStatus = orderStatus;
     this.orderItemList = orderItemList;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public Long getUserId() {
-    return userId;
-  }
-
-  public String getReceiverName() {
-    return receiverName;
-  }
-
-  public String getReceiverPhone() {
-    return receiverPhone;
-  }
-
-  public String getReceiverAddress() {
-    return receiverAddress;
-  }
-
-  public OrderStatus getOrderStatus() {
-    return orderStatus;
-  }
-
-  public List<OrderItem> getOrderItemList() {
-    return orderItemList;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
   }
 
   public enum OrderStatus {

--- a/src/main/java/com/example/freshcart/order/infrastructure/config/OrderServiceConfig.java
+++ b/src/main/java/com/example/freshcart/order/infrastructure/config/OrderServiceConfig.java
@@ -1,5 +1,7 @@
 package com.example.freshcart.order.infrastructure.config;
 
+import com.example.freshcart.optionstock.application.OptionStockService;
+import com.example.freshcart.optionstock.domain.OptionStockRepository;
 import com.example.freshcart.order.application.CartToOrderMapper;
 import com.example.freshcart.order.application.OrderItemRegister;
 import com.example.freshcart.order.application.OrderManagerFacade;
@@ -25,7 +27,7 @@ public class OrderServiceConfig {
   }
 
   @Bean
-  public OrderItemRegister orderItemService(OrderItemMapper orderItemMapper,
+  public OrderItemRegister orderItemRegister(OrderItemMapper orderItemMapper,
       OrderItemOptionMapper orderItemOptionMapper,
       OrderItemOptionGroupMapper orderItemOptionGroupMapper) {
     return new OrderItemRegisterV1(orderItemMapper, orderItemOptionMapper,
@@ -45,7 +47,7 @@ public class OrderServiceConfig {
 
   @Bean
   public OrderRegisterProcessor orderRegisterProcessor(CartToOrderMapper cartToOrderMapper,
-      OrderValidator orderValidator, OrderRepository orderRepository) {
-    return new OrderRegisterProcessor(cartToOrderMapper, orderValidator, orderRepository);
+      OrderValidator orderValidator, OptionStockService optionStockService, OrderRepository orderRepository, OptionStockRepository optionStockRepository) {
+    return new OrderRegisterProcessor(cartToOrderMapper, orderValidator, optionStockService, orderRepository, optionStockRepository);
   }
 }

--- a/src/main/java/com/example/freshcart/order/presentation/request/Cart.java
+++ b/src/main/java/com/example/freshcart/order/presentation/request/Cart.java
@@ -7,10 +7,15 @@ import com.example.freshcart.order.application.command.CartCommand.CartItemComma
 import com.example.freshcart.order.application.command.CartCommand.CartItemOptionCommand;
 import com.example.freshcart.order.application.command.CartCommand.CartItemOptionGroupCommand;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * Order Command에 필요한 정보가 모두 담겼는지 확인 필요.
  */
+
+@Getter
+@NoArgsConstructor
 public class Cart {
 
   private String receiverName;
@@ -29,22 +34,6 @@ public class Cart {
     this.cartItems = cartItems;
   }
 
-  public String getReceiverName() {
-    return receiverName;
-  }
-
-  public String getReceiverPhone() {
-    return receiverPhone;
-  }
-
-  public String getReceiverAddress() {
-    return receiverAddress;
-  }
-
-  public List<CartItem> getCartItems() {
-    return cartItems;
-  }
-
   public CartCommand toCommand() {
     return new CartCommand(this.receiverName, this.receiverPhone, this.receiverAddress,
         this.cartItems.stream().map(CartItem::toCartItemCommand).collect(toList()));
@@ -53,6 +42,8 @@ public class Cart {
   /**
    * CartItem은 Product, OrderLineItem과 매칭
    */
+  @Getter
+  @NoArgsConstructor
   public static class CartItem {
 
     private Long productId;
@@ -70,33 +61,16 @@ public class Cart {
       this.groups = groups;
     }
 
-
-    public Long getProductId() {
-      return productId;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public int getCount() {
-      return count;
-    }
-
-    public int getPrice() {
-      return price;
-    }
-
-    public List<CartItemOptionGroup> getGroups() {
-      return groups;
-    }
-
     public CartItemCommand toCartItemCommand() {
-      return new CartItemCommand(this.productId, this.name, this.price, this.count, this.groups.stream().map(CartItemOptionGroup::toCartItemOptionGroupCommand).collect(toList()));
+      return new CartItemCommand(this.productId, this.name, this.price, this.count,
+          this.groups.stream().map(CartItemOptionGroup::toCartItemOptionGroupCommand)
+              .collect(toList()));
     }
 
   }
 
+  @Getter
+  @NoArgsConstructor
   public static class CartItemOptionGroup {
 
     private Long productOptionGroupId;
@@ -110,17 +84,6 @@ public class Cart {
       this.options = options;
     }
 
-    public Long getProductOptionGroupId() {
-      return productOptionGroupId;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public List<CartItemOption> getOptions() {
-      return options;
-    }
 
     public CartItemOptionGroupCommand toCartItemOptionGroupCommand() {
       return new CartItemOptionGroupCommand(this.productOptionGroupId, this.name,
@@ -128,6 +91,8 @@ public class Cart {
     }
   }
 
+  @Getter
+  @NoArgsConstructor
   public static class CartItemOption {
 
     private Long productOptionId;
@@ -140,17 +105,6 @@ public class Cart {
       this.price = price;
     }
 
-    public Long getProductOptionId() {
-      return productOptionId;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public int getPrice() {
-      return price;
-    }
 
     public CartItemOptionCommand toCartItemOptionCommand() {
       return new CartItemOptionCommand(this.productOptionId, this.name, this.price);


### PR DESCRIPTION
[개요]
-주문이 성공적으로 처리 되면, 재고가 차감되는 직 로직 구현.  

[테스트 내역]
-재고가 부족할 경우, 재고가 부족하다는 exception 발생.
-해당 제품의 재고가 등록되어 있지 않을 경우, 재고가 없다는 EXCEPTION 발생 
-제품 주문 수량 (count)에 따라 재고 데이터가 차감됨을 확인. 

[고민되는 것] 
옵션 그룹에는 여러 옵션 선택이 가능한 경우도 있습니다. 따라서 아래와 같이 로직을 만들었습니다. 

카트에 담긴 제품 조회 (1차 for문) 
옵션 그룹 조회 (2차 for문)
옵션 조회 (3차 for문)  - 옵션 별로 재고 확인 후 차감. 

3중 for 문을 사용하는 것은 처음인데, 이렇게 했을 때 고려해야 하는 단점이나/ 비효율성이 있을까요? 




