### PR TITLE
Feature/22 product register refactor

### DIFF
--- a/http-test/product.http
+++ b/http-test/product.http
@@ -20,12 +20,12 @@ Content-Type: application/json
             "optionDetailRegisterList":
             [
             {
-            "optionName": "30g",
+            "name": "30g",
             "price": 0
             },
 
             {
-            "optionName": "60g",
+            "name": "60g",
             "price": 2000
             }
             ]
@@ -39,12 +39,12 @@ Content-Type: application/json
             "optionDetailRegisterList":
             [
             {
-            "optionName": "견과류",
+            "name": "견과류",
             "price": 1000
             },
 
             {
-            "optionName": "크랜베리",
+            "name": "크랜베리",
             "price": 500
             }
             ]
@@ -76,12 +76,12 @@ Content-Type: application/json
       "optionDetailRegisterList":
       [
         {
-          "optionName": "100g",
+          "name": "100g",
           "price": 0
         },
 
         {
-          "optionName": "200g",
+          "name": "200g",
           "price": 4000
         }
       ]
@@ -95,17 +95,17 @@ Content-Type: application/json
       "optionDetailRegisterList":
       [
         {
-          "optionName": "청경채",
+          "name": "청경채",
           "price": 1000
         },
 
         {
-          "optionName": "알배추",
+          "name": "알배추",
           "price": 500
         },
 
         {
-          "optionName": "버섯",
+          "name": "버섯",
           "price": 2000
         }
       ]

--- a/src/main/java/com/example/freshcart/authentication/application/LoginUser.java
+++ b/src/main/java/com/example/freshcart/authentication/application/LoginUser.java
@@ -3,6 +3,8 @@ package com.example.freshcart.authentication.application;
 import com.example.freshcart.authentication.Role;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
 import org.springframework.data.annotation.Id;
 
 /**
@@ -10,6 +12,7 @@ import org.springframework.data.annotation.Id;
  * RedisRepository아닌 RedisTemplate 사용 시 LoginUser 형태로 저장
  */
 
+@Getter
 public class LoginUser implements Serializable {
 
   @Id
@@ -30,6 +33,7 @@ public class LoginUser implements Serializable {
     this.createdAt = createdAt;
   }
 
+  @Builder
   public LoginUser(String id, String sessionId, Long userId, String email,
       Role role, LocalDateTime createdAt) {
     this.id = id;
@@ -48,31 +52,8 @@ public class LoginUser implements Serializable {
     return new LoginUser(sessionId, userId, email, role, createdAt);
   }
 
-  public Long getUserId() {
-    return userId;
-  }
-
-  public String getSessionId() {
-    return sessionId;
-  }
-
   public void setSessionId(String sessionId) {
     this.sessionId = sessionId;
   }
 
-  public String getEmail() {
-    return email;
-  }
-
-  public Role getRole() {
-    return role;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public String getId() {
-    return id;
-  }
 }

--- a/src/main/java/com/example/freshcart/order/application/OrderValidator.java
+++ b/src/main/java/com/example/freshcart/order/application/OrderValidator.java
@@ -88,9 +88,9 @@ public class OrderValidator {
   }
 
   public void validateOrderOption(OrderItemOption orderItemOption) {
-    String optionName = optionRepository.findById(orderItemOption.getOptionId())
-        .getOptionName();
-    if (!orderItemOption.getName().equals(optionName)) {
+    String name = optionRepository.findById(orderItemOption.getOptionId())
+        .getName();
+    if (!orderItemOption.getName().equals(name)) {
       throw new OrderItemOptionNotFoundException();
     }
   }

--- a/src/main/java/com/example/freshcart/product/application/ProductService.java
+++ b/src/main/java/com/example/freshcart/product/application/ProductService.java
@@ -74,14 +74,8 @@ public class ProductService {
         optionGroupRepository.save(optionGroup);
 
         List<OptionDetailRegister> optionDetailRegisterList = optionSet.getOptionDetailRegisterList();
-        for (OptionDetailRegister element : optionDetailRegisterList) {
-          Option option = new Option(
-              element.getOptionName(),
-              element.getPrice(),
-              optionGroup.getId(),
-              user.getUserId());
-          optionRepository.save(option);
-        }
+        List<Option> options = optionSet.toOptions(optionDetailRegisterList, optionGroup);
+        optionRepository.save(options);
       }
     }
   }

--- a/src/main/java/com/example/freshcart/product/application/ProductService.java
+++ b/src/main/java/com/example/freshcart/product/application/ProductService.java
@@ -57,12 +57,7 @@ public class ProductService {
         request.getCategoryId(),
         user.getUserId());
 
-    //옵션이 여러개일 경우 다른 쿼리 사용.
-    if(request.getOptionSet()!=null){
-      productRepository.saveWithOptions(product);
-    }
     productRepository.save(product);
-    log.info(" product id 확인: " + product.getId());
 
     if (request.getOptionSet() != null) {
       for (OptionSet optionSet : request.getOptionSet()) {

--- a/src/main/java/com/example/freshcart/product/application/ProductService.java
+++ b/src/main/java/com/example/freshcart/product/application/ProductService.java
@@ -47,37 +47,21 @@ public class ProductService {
    * 단일 제품일 경우 product만 저장하고 옵션이 있는 제품은 OptionGroupRegister와 Option 저장.
    */
   public void addProduct(LoginUser user, ProductRegisterRequest request) {
-
-    Product product = new Product(
-        request.getName(),
-        request.getPrice(),
-        request.getStatus(),
-        request.getDescription(),
-        request.isSingleType(),
-        request.getCategoryId(),
-        user.getUserId());
-
+    Product product = request.toProduct(user);
     productRepository.save(product);
 
     if (request.getOptionSet() != null) {
       for (OptionSet optionSet : request.getOptionSet()) {
         OptionGroupRegister optionGroupRegister = optionSet.getOptionGroupRegister();
-        OptionGroup optionGroup = new OptionGroup(
-            optionGroupRegister.getOptionGroupName(),
-            optionGroupRegister.isRequiredOption(),
-            optionGroupRegister.isExclusive(),
-            optionGroupRegister.getMinimumOrder(),
-            optionGroupRegister.getMaximumOrder(),
-            product.getId(),
-            user.getUserId());
+        OptionGroup optionGroup = optionGroupRegister.toOptionGroup(user, product);
         optionGroupRepository.save(optionGroup);
 
         List<OptionDetailRegister> optionDetailRegisterList = optionSet.getOptionDetailRegisterList();
         List<Option> options = optionSet.toOptions(optionDetailRegisterList, optionGroup);
         optionRepository.save(options);
       }
+      }
     }
-  }
 
   //OptionId가 주어지면, Option을 찾는다.
   public Option getOption(Long optionId){

--- a/src/main/java/com/example/freshcart/product/application/ProductService.java
+++ b/src/main/java/com/example/freshcart/product/application/ProductService.java
@@ -57,6 +57,10 @@ public class ProductService {
         request.getCategoryId(),
         user.getUserId());
 
+    //옵션이 여러개일 경우 다른 쿼리 사용.
+    if(request.getOptionSet()!=null){
+      productRepository.saveWithOptions(product);
+    }
     productRepository.save(product);
     log.info(" product id 확인: " + product.getId());
 

--- a/src/main/java/com/example/freshcart/product/domain/Option.java
+++ b/src/main/java/com/example/freshcart/product/domain/Option.java
@@ -1,6 +1,7 @@
 package com.example.freshcart.product.domain;
 
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,16 +10,16 @@ import lombok.NoArgsConstructor;
 public class Option {
 
   private Long id;
-  private String optionName;
+  private String name;
   private int price;
   private Long optionGroupId;
   private Long sellerId;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
-
-  public Option(String optionName, int price, Long optionGroupId, Long sellerId) {
-    this.optionName = optionName;
+  @Builder
+  public Option(String name, int price, Long optionGroupId, Long sellerId) {
+    this.name = name;
     this.price = price;
     this.optionGroupId = optionGroupId;
     this.sellerId = sellerId;

--- a/src/main/java/com/example/freshcart/product/domain/OptionRepository.java
+++ b/src/main/java/com/example/freshcart/product/domain/OptionRepository.java
@@ -1,8 +1,10 @@
 package com.example.freshcart.product.domain;
 
+import java.util.List;
+
 public interface OptionRepository {
 
-  Option save(Option option);
-
+//  Option save(Option option);
+  List<Option> save(List<Option> options);
   Option findById(Long optionId);
 }

--- a/src/main/java/com/example/freshcart/product/domain/OptionRepository.java
+++ b/src/main/java/com/example/freshcart/product/domain/OptionRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 public interface OptionRepository {
 
-//  Option save(Option option);
   List<Option> save(List<Option> options);
   Option findById(Long optionId);
 }

--- a/src/main/java/com/example/freshcart/product/domain/Product.java
+++ b/src/main/java/com/example/freshcart/product/domain/Product.java
@@ -3,8 +3,11 @@ package com.example.freshcart.product.domain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class Product {
 
@@ -25,9 +28,7 @@ public class Product {
     BEING_PREPARED, AVAILABLE, UNAVAILABLE,
   }
 
-  public Product() {
-  }
-
+  @Builder
   public Product(String name, int price, Status status, String description, Boolean singleType,
       int categoryId, Long sellerId) {
     this.name = name;

--- a/src/main/java/com/example/freshcart/product/domain/ProductRepository.java
+++ b/src/main/java/com/example/freshcart/product/domain/ProductRepository.java
@@ -9,4 +9,6 @@ public interface ProductRepository {
   List<Product> findAll();
 
   Product findById(Long productId);
+
+  Product saveWithOptions(Product product);
 }

--- a/src/main/java/com/example/freshcart/product/infrastructure/OptionMapper.java
+++ b/src/main/java/com/example/freshcart/product/infrastructure/OptionMapper.java
@@ -1,12 +1,13 @@
 package com.example.freshcart.product.infrastructure;
 import com.example.freshcart.product.domain.Option;
 
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface OptionMapper {
 
-  void insert(Option option);
+  void insert(List<Option> option);
 
   Option findById(Long optionId);
 }

--- a/src/main/java/com/example/freshcart/product/infrastructure/OptionMapperRepositoryAdaptor.java
+++ b/src/main/java/com/example/freshcart/product/infrastructure/OptionMapperRepositoryAdaptor.java
@@ -2,6 +2,7 @@ package com.example.freshcart.product.infrastructure;
 
 import com.example.freshcart.product.domain.Option;
 import com.example.freshcart.product.domain.OptionRepository;
+import java.util.List;
 
 
 public class OptionMapperRepositoryAdaptor implements OptionRepository {
@@ -14,9 +15,9 @@ public class OptionMapperRepositoryAdaptor implements OptionRepository {
   }
 
   @Override
-  public Option save(Option option) {
-    optionMapper.insert(option);
-    return option;
+  public List<Option> save(List<Option> options) {
+    optionMapper.insert(options);
+    return options;
   }
 
   @Override

--- a/src/main/java/com/example/freshcart/product/infrastructure/ProductMapper.java
+++ b/src/main/java/com/example/freshcart/product/infrastructure/ProductMapper.java
@@ -12,4 +12,6 @@ public interface ProductMapper {
   List<Product> findAll();
 
   Product findById(Long productId);
+
+  void insertWithOptions(Product product);
 }

--- a/src/main/java/com/example/freshcart/product/infrastructure/ProductMapperRepositoryAdaptor.java
+++ b/src/main/java/com/example/freshcart/product/infrastructure/ProductMapperRepositoryAdaptor.java
@@ -29,4 +29,10 @@ public class ProductMapperRepositoryAdaptor implements ProductRepository {
   public Product findById(Long productId) {
     return productMapper.findById(productId);
   }
+
+  @Override
+  public Product saveWithOptions(Product product) {
+    productMapper.insertWithOptions(product);
+    return product;
+  }
 }

--- a/src/main/java/com/example/freshcart/product/presentation/request/OptionDetailRegister.java
+++ b/src/main/java/com/example/freshcart/product/presentation/request/OptionDetailRegister.java
@@ -15,13 +15,13 @@ import org.hibernate.validator.constraints.Range;
 public class OptionDetailRegister {
 
   @NotBlank(message = "옵션 이름을 입력해주세요")
-  private String optionName;
+  private String name;
   @Range(min = 10, message = "상품 가격은 10원 이상이어야 합니다.")
   private int price;
 
   @Builder
-  public OptionDetailRegister(String optionName, int price) {
-    this.optionName = optionName;
+  public OptionDetailRegister(String name, int price) {
+    this.name = name;
     this.price = price;
   }
 

--- a/src/main/java/com/example/freshcart/product/presentation/request/OptionGroupRegister.java
+++ b/src/main/java/com/example/freshcart/product/presentation/request/OptionGroupRegister.java
@@ -1,6 +1,9 @@
 package com.example.freshcart.product.presentation.request;
 
 
+import com.example.freshcart.authentication.application.LoginUser;
+import com.example.freshcart.product.domain.OptionGroup;
+import com.example.freshcart.product.domain.Product;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -54,5 +57,11 @@ public class OptionGroupRegister {
     this.exclusive = exclusive;
     this.minimumOrder = minimumOrder;
     this.maximumOrder = maximumOrder;
+  }
+
+  public OptionGroup toOptionGroup(LoginUser user,
+      Product product) {
+    return new OptionGroup(this.optionGroupName, this.requiredOption, this.exclusive, this.minimumOrder, this.maximumOrder,
+        product.getId(),user.getUserId());
   }
 }

--- a/src/main/java/com/example/freshcart/product/presentation/request/OptionSet.java
+++ b/src/main/java/com/example/freshcart/product/presentation/request/OptionSet.java
@@ -1,13 +1,18 @@
 package com.example.freshcart.product.presentation.request;
 
+import com.example.freshcart.product.domain.Option;
+import com.example.freshcart.product.domain.OptionGroup;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * OptionGroup 한 개당 하나 이상의 옵션을 갖는다 (ex. 중량 - 50g, 100g 등)
  */
 
+@NoArgsConstructor
 public class OptionSet {
 
   @NotBlank(message = "옵션 그룹을 최소 하나 입력하세요")
@@ -30,4 +35,18 @@ public class OptionSet {
   public List<OptionDetailRegister> getOptionDetailRegisterList() {
     return optionDetailRegisterList;
   }
+
+  public List<Option> toOptions(List<OptionDetailRegister> optionDetailRegisterList, OptionGroup optionGroup){
+    return optionDetailRegisterList
+        .stream()
+        .map(optionDetailRegister ->
+            Option.builder()
+                .name(optionDetailRegister.getName())
+                .price(optionDetailRegister.getPrice())
+                .optionGroupId(optionGroup.getId())
+                .sellerId(optionGroup.getSellerId())
+                .build())
+        .collect(Collectors.toList());
+  }
+
 }

--- a/src/main/java/com/example/freshcart/product/presentation/request/ProductRegisterRequest.java
+++ b/src/main/java/com/example/freshcart/product/presentation/request/ProductRegisterRequest.java
@@ -1,21 +1,25 @@
 package com.example.freshcart.product.presentation.request;
 
+import com.example.freshcart.authentication.application.LoginUser;
+import com.example.freshcart.product.domain.Product;
 import com.example.freshcart.product.domain.Product.Status;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Singular;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.lang.Nullable;
 
 /**
- * 셀러가 필수 정보를 담아서 회원 가입 요청. 필수이기 때문에 @NotNull과 @Valid로 확인
- * Command 로 변환하여 전달 필요. Product-Status를 참조하고 있음.
+ * 셀러가 필수 정보를 담아서 회원 가입 요청. 필수이기 때문에 @NotNull과 @Valid로 확인 Command 로 변환하여 전달 필요. Product-Status를 참조하고
+ * 있음.
  */
 
 @Getter
+@NoArgsConstructor
 public class ProductRegisterRequest {
 
   @NotBlank(message = "제품 이름을 입력해주세요")
@@ -33,11 +37,9 @@ public class ProductRegisterRequest {
   private List<OptionSet> optionSet;
 
 
-  public ProductRegisterRequest() {
-  }
-
   @Builder
-  public ProductRegisterRequest(String name, int price, Status status,String description, boolean singleType,int categoryId, List<OptionSet> optionSet){
+  public ProductRegisterRequest(String name, int price, Status status, String description,
+      boolean singleType, int categoryId, List<OptionSet> optionSet) {
     this.name = name;
     this.price = price;
     this.status = status;
@@ -45,5 +47,11 @@ public class ProductRegisterRequest {
     this.singleType = singleType;
     this.categoryId = categoryId;
     this.optionSet = optionSet;
+  }
+
+  public Product toProduct(LoginUser user) {
+    return new Product(this.name, this.price, this.status, this.description, this.singleType,
+        this.categoryId,
+        user.getUserId());
   }
 }

--- a/src/main/resources/mapper/option-mapper.xml
+++ b/src/main/resources/mapper/option-mapper.xml
@@ -3,18 +3,20 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.freshcart.product.infrastructure.OptionMapper">
 
-  <insert id="insert" keyProperty="id" useGeneratedKeys="true">
+  <insert id="insert" keyProperty="id" parameterType ="java.util.List" useGeneratedKeys="true">
     insert into `option` (name, price, option_group_id, seller_id)
-    values (#{optionName}, #{price}, #{optionGroupId}, #{sellerId});
-  </insert>
+    values
+    <foreach collection="list" index="index" item="option" separator=",">
+    (#{option.name}, #{option.price}, #{option.optionGroupId}, #{option.sellerId})
+    </foreach>
+</insert>
 
   <resultMap id="optionResultMap" type="com.example.freshcart.product.domain.Option">
-    <result column="name" property="optionName"/>
     <result column="option_group_id" property="optionGroupId"/>
     <result column="seller_id" property="sellerId"/>
     <result column="created_at" property="createdAt"/>
     <result column="updated_at" property="updatedAt"/>
-  </resultMap>
+    </resultMap>
 
   <select id="findById" resultMap="optionResultMap">
     select id, name, price, option_group_id, seller_id, created_at, updated_at

--- a/src/main/resources/mapper/product-mapper.xml
+++ b/src/main/resources/mapper/product-mapper.xml
@@ -7,21 +7,6 @@
     values (#{name}, #{price}, #{status}, #{description}, #{singleType}, #{categoryId}, #{sellerId});
   </insert>
 
-  <insert id="insertWithOptions" keyProperty="id" parameterType ="java.util.List" useGeneratedKeys="true">
-    insert into product (name, price, status, description, single_type, category_id, seller_id)
-    values (#{name}, #{price}, #{status}, #{description}, #{singleType}, #{categoryId}, #{sellerId});
-    insert into order_item_option_group (option_group_id, name, order_item_id)
-    values (#{optionGroupId}, #{name}, #{orderItemId});
-    <foreach collection="list" index="index" item="OptionGroup" separator=",">
-      (#{option.name}, #{option.price}, #{option.optionGroupId}, #{option.sellerId})
-    </foreach>
-    insert into `option` (name, price, option_group_id, seller_id)
-    values
-    <foreach collection="list" index="index" item="option" separator=",">
-      (#{option.name}, #{option.price}, #{option.optionGroupId}, #{option.sellerId})
-    </foreach>
-  </insert>
-
   <resultMap id="productResultMap" type="com.example.freshcart.product.domain.Product">
     <result column="single_type" property="singleType"/>
     <result column="category_id" property="categoryId"/>

--- a/src/main/resources/mapper/product-mapper.xml
+++ b/src/main/resources/mapper/product-mapper.xml
@@ -7,6 +7,21 @@
     values (#{name}, #{price}, #{status}, #{description}, #{singleType}, #{categoryId}, #{sellerId});
   </insert>
 
+  <insert id="insertWithOptions" keyProperty="id" parameterType ="java.util.List" useGeneratedKeys="true">
+    insert into product (name, price, status, description, single_type, category_id, seller_id)
+    values (#{name}, #{price}, #{status}, #{description}, #{singleType}, #{categoryId}, #{sellerId});
+    insert into order_item_option_group (option_group_id, name, order_item_id)
+    values (#{optionGroupId}, #{name}, #{orderItemId});
+    <foreach collection="list" index="index" item="OptionGroup" separator=",">
+      (#{option.name}, #{option.price}, #{option.optionGroupId}, #{option.sellerId})
+    </foreach>
+    insert into `option` (name, price, option_group_id, seller_id)
+    values
+    <foreach collection="list" index="index" item="option" separator=",">
+      (#{option.name}, #{option.price}, #{option.optionGroupId}, #{option.sellerId})
+    </foreach>
+  </insert>
+
   <resultMap id="productResultMap" type="com.example.freshcart.product.domain.Product">
     <result column="single_type" property="singleType"/>
     <result column="category_id" property="categoryId"/>

--- a/src/test/java/com/example/freshcart/fixture/UserFixture.java
+++ b/src/test/java/com/example/freshcart/fixture/UserFixture.java
@@ -6,25 +6,22 @@ import static com.example.freshcart.authentication.Role.USER;
 import com.example.freshcart.user.application.command.LoginCommand;
 import com.example.freshcart.user.application.command.SignupCommand;
 import com.example.freshcart.user.domain.User;
-import com.example.freshcart.user.presentation.request.SignupRequest;
 
 /**
- * 판매자 유저, 일반 유저 생성.
- * UserService에서 password를 encrypt를 한다.
- * UserRequestDto를 먼저 만든다.
+ * 판매자 유저, 일반 유저 생성. UserService에서 password를 encrypt를 한다. UserRequestDto를 먼저 만든다.
  */
 public class UserFixture {
-  public static User.UserBuilder aUser(){
-    return User.builder().email("user1@gmail.com").password("tgbv1245").phoneNumber("01033334444").name("유저1").role(USER);
+
+
+  public static User.UserBuilder aSeller() {
+    return User.builder().email("seller1@gmail.com").password("lopp1245").phoneNumber("01011111111")
+        .name("판매자1").role(SELLER);
   }
 
-  public static User.UserBuilder aSeller(){
-    return User.builder().email("seller1@gmail.com").password("lopp1245").phoneNumber("01011111111").name("판매자1").role(SELLER);
-  }
 
   //가입에만 사용하는 데이터
   //유저 회원 가입 신청
-  public static SignupCommand.SignupCommandBuilder aSignupCommand(){
+  public static SignupCommand.SignupCommandBuilder aSignupCommand() {
     return SignupCommand.builder()
         .email("user1@gmail.com")
         .password("tgbv1245")
@@ -34,7 +31,7 @@ public class UserFixture {
   }
 
   //판매자 회원 가입 신청
-  public static SignupCommand.SignupCommandBuilder aSellerSignupRequest(){
+  public static SignupCommand.SignupCommandBuilder aSellerSignupRequest() {
     return SignupCommand.builder()
         .email("seller1@gmail.com")
         .password("lopp1245")
@@ -43,7 +40,7 @@ public class UserFixture {
         .role(SELLER);
   }
 
-  public static LoginCommand.LoginCommandBuilder aLoginCommand(){
+  public static LoginCommand.LoginCommandBuilder aLoginCommand() {
     return LoginCommand.builder()
         .email("seller1@gmail.com")
         .password("lopp1245");

--- a/src/test/java/com/example/freshcart/product/application/ProductServiceTest.java
+++ b/src/test/java/com/example/freshcart/product/application/ProductServiceTest.java
@@ -1,33 +1,91 @@
 package com.example.freshcart.product.application;
 
 import static com.example.freshcart.product.fixture.ProductFixture.aProductRegisterRequest;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.example.freshcart.authentication.Role;
+import com.example.freshcart.authentication.application.LoginUser;
+import com.example.freshcart.product.domain.Option;
+import com.example.freshcart.product.domain.OptionGroup;
+import com.example.freshcart.product.domain.OptionGroupRepository;
+import com.example.freshcart.product.domain.OptionRepository;
+import com.example.freshcart.product.domain.Product;
+import com.example.freshcart.product.domain.ProductRepository;
+import com.example.freshcart.product.domain.exception.NotSellerException;
 import com.example.freshcart.product.presentation.request.ProductRegisterRequest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(MockitoExtension.class)
 public class ProductServiceTest {
+  @InjectMocks
+  private ProductService productService;
+  @Mock
+  private ProductRepository productRepository;
+  @Mock
+  private OptionGroupRepository optionGroupRepository;
+  @Mock
+  private OptionRepository optionRepository;
+
+  private LoginUser loginUser;
+  private ProductRegisterRequest request;
+
+  @BeforeEach
+  void init(){
+    productService = new ProductService(productRepository, optionGroupRepository, optionRepository);
+  }
 
   @DisplayName("판매자가 아닌 유저가 숙소 등록을 시도할 경우 NotSeller예외가 발생한다")
   @Test
   public void createProduct_fail(){
-    //given 일반 유저가
-    aProductRegisterRequest();
+    //given 로그인 유저가 Role이 Seller가 아님.
+    loginUser = new LoginUser("sessionId", 1L, "user1@gmail.com", Role.USER, LocalDateTime.now());
+    assertThrows(NotSellerException.class, () -> productService.register(loginUser, request));
   }
 
-  @DisplayName("판매자인 유저가 숙소 등록을 시도할 경우 정상")
-  @Test
-  public void createProduct_success(){
-    //given 일반 유저가
-    aProductRegisterRequest();
-  }
-
-  @DisplayName("옵션이 있는 제품 저장에 성공 시 id 가 생성된다 ")
-  @Test
-  void createProductwithOptions(){
-
-  }
-
-
+  //ArgumentCaptor 로 객체가 잘 저장되었는지 확인할 것.
+//  @DisplayName("판매자인 유저가 숙소 등록을 시도할 경우 정상")
+//  @Test
+//  public void createProduct_success(){
+//    //given
+//    loginUser = new LoginUser("sessionId", 1L, "seller1@gmail.com", Role.SELLER, LocalDateTime.now());
+//    request = aProductRegisterRequest().build();
+//
+//    ArgumentCaptor<Product> productCapture= ArgumentCaptor.forClass(Product.class);
+//    ArgumentCaptor<OptionGroup> optionGroupCapture= ArgumentCaptor.forClass(OptionGroup.class);
+//    ArgumentCaptor<Option> optionCapture= ArgumentCaptor.forClass(Option.class);
+//
+//    //WHEN
+//    productService.register(loginUser, request);
+//
+//    //THEN
+//    verify(productRepository).save(any(Product.class));
+//    Product savedProduct = productCapture.getValue();
+//    assertThat(savedProduct.getName()).isEqualTo(request.getName());
+//
+//    //OptionGroup이 여러개인 상황이라면 너무 복잡할 것 같다.
+//    verify(optionGroupRepository).save(any(OptionGroup.class));
+//    OptionGroup savedOptionGroup = optionGroupCapture.getValue();
+////    assertThat(savedOptionGroup.getOptionGroupName()).isEqualTo(request.getOptionSet().getOptionGroupRegister);
+//
+//    verify(optionRepository).save(any(Option.class));
+//    Option savedOption = optionCapture.getValue();
+//    assertThat(savedOption.getOptionName()).isEqualTo(request.getOptionSet());
+//  }
+//
+//  @DisplayName("옵션이 있는 제품 저장에 성공 시 id 가 생성된다 ")
+//  @Test
+//  void createProductwithOptions(){
+//
+//  }
 }

--- a/src/test/java/com/example/freshcart/product/application/ProductServiceTest.java
+++ b/src/test/java/com/example/freshcart/product/application/ProductServiceTest.java
@@ -80,7 +80,7 @@ public class ProductServiceTest {
 //
 //    verify(optionRepository).save(any(Option.class));
 //    Option savedOption = optionCapture.getValue();
-//    assertThat(savedOption.getOptionName()).isEqualTo(request.getOptionSet());
+//    assertThat(savedOption.getname()).isEqualTo(request.getOptionSet());
 //  }
 //
 //  @DisplayName("옵션이 있는 제품 저장에 성공 시 id 가 생성된다 ")

--- a/src/test/java/com/example/freshcart/product/fixture/ProductFixture.java
+++ b/src/test/java/com/example/freshcart/product/fixture/ProductFixture.java
@@ -34,7 +34,7 @@ public class ProductFixture {
             anOptionDetailRegister()
                 .build(),
             anOptionDetailRegister()
-                .optionName("60g")
+                .name("60g")
                 .price(2000)
                 .build()))
         .optionGroupRegister(
@@ -42,11 +42,11 @@ public class ProductFixture {
                 .minimumOrder(1).maximumOrder(2).build()).
         optionDetailRegisterList(Arrays.asList(
             anOptionDetailRegister()
-                .optionName("견과류")
+                .name("견과류")
                 .price(1000)
                 .build(),
             anOptionDetailRegister()
-                .optionName("크랜베리")
+                .name("크랜베리")
                 .price(500)
                 .build()));
 
@@ -63,7 +63,7 @@ public class ProductFixture {
 
   public static OptionDetailRegister.OptionDetailRegisterBuilder anOptionDetailRegister() {
     return OptionDetailRegister.builder()
-        .optionName("30g")
+        .name("30g")
         .price(0);
   }
 
@@ -83,11 +83,11 @@ public class ProductFixture {
         optionGroupRegister(anOptionGroupRegister().build()).
         optionDetailRegisterList(Arrays.asList(
             anOptionDetailRegister()
-                .optionName("100g")
+                .name("100g")
                 .price(0)
                 .build(),
             anOptionDetailRegister()
-                .optionName("200g")
+                .name("200g")
                 .price(4000)
                 .build()))
         .optionGroupRegister(
@@ -95,15 +95,15 @@ public class ProductFixture {
                 .minimumOrder(1).maximumOrder(3).build()).
         optionDetailRegisterList(Arrays.asList(
             anOptionDetailRegister()
-                .optionName("청경채")
+                .name("청경채")
                 .price(1000)
                 .build(),
             anOptionDetailRegister()
-                .optionName("알배추")
+                .name("알배추")
                 .price(500)
                 .build(),
             anOptionDetailRegister()
-                .optionName("버섯")
+                .name("버섯")
                 .price(2000)
                 .build()));
 


### PR DESCRIPTION
[개요] 
제품을 등록할 때, 제품 - 옵션 그룹 (ex. 맛) - 옵션 (ex. 딸기맛, 포도맛 )이 일대 다 관계 입니다. 
제품을 저장할 때,  이중 for 문으로 저장하면서 쿼리가 옵션 그룹 수 x 옵션 수 만큼 추가로 날아가는 문제가 있어서, 개선하고자 foreach를 활용하였습니다. 
[테스트] 
옵션개수에 따라 N개 발생하는 insert 쿼리를 1개로 줄였습니다. 
제품이 잘 저장되는 것 확인하였습니다. 
[고민 되는 것] 
현재 쿼리를 더 개선할 여지가 있을까요?
optionGroup도 줄이고 싶었는데, table이 다른 상황에서는 foreach를 활용하기 어려웠습니다. 
insert all into를 고려하였으나, 이는 oracle에서만 가능하고 mysql에서는 불가해서
우선은 optionGroup만 수정하였습니다. 

